### PR TITLE
feat: Variables y Output

### DIFF
--- a/terraform/Efimero/output.tf
+++ b/terraform/Efimero/output.tf
@@ -1,0 +1,33 @@
+output "rds_endpoint" {
+  description = "Endpoint de la base de datos RDS"
+  value       = aws_db_instance.bere_db.endpoint
+}
+
+output "rds_connection_url" {
+  description = "URL completa de conexión a la base de datos"
+  value       = "postgres://${aws_db_instance.bere_db.username}:${aws_db_instance.bere_db.password}@${aws_db_instance.bere_db.endpoint}:5432/${aws_db_instance.bere_db.db_name}"
+  sensitive   = true
+}
+
+# IP pública
+output "backend_public_ip" {
+  description = "IP pública del backend"
+  value       = data.terraform_remote_state.elastic_ip.outputs.elasticIP
+}
+
+# DNS público
+output "backend_public_dns" {
+  description = "DNS público del backend"
+  value       = aws_instance.bere_backend.public_dns
+}
+
+output "backend_url" {
+  description = "URL de acceso al backend"
+  value       = "http://${data.terraform_remote_state.elastic_ip.outputs.elasticIP}:8080"
+}
+
+output "frontend_url" {
+  description = "URL del frontent"
+  value = "http://bere-frontend.s3.${var.aws_region}.amazonaws.com/index.html"
+  
+}

--- a/terraform/Efimero/variables.tf
+++ b/terraform/Efimero/variables.tf
@@ -1,0 +1,3 @@
+variable "aws_region" {
+  default = "us-east-2"
+}


### PR DESCRIPTION
Este cambio en Terraform agrega salidas (outputs) y una variable para facilitar el acceso a información clave de la infraestructura desplegada:

**Variable:**
Define aws_region con valor predeterminado us-east-2 para especificar la región de AWS.
**Salidas:**
rds_endpoint: Proporciona el endpoint de la base de datos RDS.
rds_connection_url: Genera una URL completa de conexión a la base de datos PostgreSQL (marcada como sensible por contener credenciales).
backend_public_ip: Muestra la IP pública del backend, obtenida de un estado remoto de Terraform.
backend_public_dns: Devuelve el DNS público de la instancia EC2 del backend.
backend_url: Proporciona la URL de acceso al backend (http://<IP>:8080).
frontend_url: Indica la URL del frontend alojado en un bucket S3.