### PR TITLE
fix:Corrigiendo el output y agregando la variable eip_ip que es el valor de la ip elastica

### DIFF
--- a/terraform/Efimero/output.tf
+++ b/terraform/Efimero/output.tf
@@ -12,7 +12,7 @@ output "rds_connection_url" {
 # IP pública
 output "backend_public_ip" {
   description = "IP pública del backend"
-  value       = "${local.eip}"
+  value       = "${local.eip_ip}"
 }
 
 # DNS público
@@ -23,7 +23,7 @@ output "backend_public_dns" {
 
 output "backend_url" {
   description = "URL de acceso al backend"
-  value       = "http://${local.eip}:8080"
+  value       = "http://${local.eip_ip}:8080"
 }
 
 output "frontend_url" {

--- a/terraform/Efimero/variables.tf
+++ b/terraform/Efimero/variables.tf
@@ -15,6 +15,7 @@ variable "aws_region" {
 locals {
   vpc_id  = data.terraform_remote_state.Persistente.outputs.VpcIP
   eip     = data.terraform_remote_state.Persistente.outputs.elastic_ip_allocation_id
+  eip_ip  = data.terraform_remote_state.Persistente.outputs.elasticIP
   subnet_2a = data.terraform_remote_state.Persistente.outputs.aws_subnet_public_subnet-us-est-2a
   subnet_2b = data.terraform_remote_state.Persistente.outputs.aws_subnet_public_subnet-us-est-2b
 }


### PR DESCRIPTION
Se modifico:
**terraform/Efimero/output.tf** , la salida para mostrar la ip elástica y no la id de la ip elástica.

**terraform/Efimero/variables.tf** , se agrego la variable eip_ip , para representar el valor de la ip elástica.