### PR TITLE
fix:Corrigiendo el url permitida en cross origin

### DIFF
--- a/terraform/Efimero/api-gateway.tf
+++ b/terraform/Efimero/api-gateway.tf
@@ -2,7 +2,7 @@ resource "aws_apigatewayv2_api" "backend_api" {
   name          = "BereBackendAPI"
   protocol_type = "HTTP"
   cors_configuration {
-        allow_origins     = ["https://d1l6zgkey4sk0l.cloudfront.net"]
+        allow_origins     = ["${local.front_url}"]
         allow_methods     = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
         allow_headers     = ["Content-Type", "Authorization"]
         expose_headers    = ["*"]


### PR DESCRIPTION
Modificando :
**terraform/Efimero/api-gateway.tf** Se modifico el atributo allow_origins , y se coloco una variable local (local.front_url), con el fin de permitir envió de solicitudes al backend a la url del frontend, recordar que cada vez que se destruye y vuelve a crear esta cambia, por eso se asigna el valor de una variable.