### PR TITLE
fix:Corrigiendo el user_Data para instalar maven y git

### DIFF
--- a/jenkins/docker-compose.yaml
+++ b/jenkins/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
     volumes:
       - jenkins_home:/var/jenkins_home
       - /var/run/docker.sock:/var/run/docker.sock
+      - /home/upao/.ssh/id_rsa:/home/upao/.ssh/id_rsa:ro
     privileged: true
     environment:
       - JENKINS_URL=http://localhost:8080/

--- a/jenkins/entrypoint.sh
+++ b/jenkins/entrypoint.sh
@@ -9,6 +9,18 @@ if [ -S /var/run/docker.sock ]; then
     chmod 660 /var/run/docker.sock
 fi
 
+if [ -f /home/upao/.ssh/id_rsa ]; then
+    echo "Configurando ~/.ssh/config para evitar prompts SSH..."
+    mkdir -p /home/upao/.ssh
+    cat > /home/upao/.ssh/config <<EOF
+Host *
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+EOF
+    chmod 600 /home/upao/.ssh/config
+    chown jenkins:jenkins /home/upao/.ssh/config
+fi
+
 usermod -aG docker jenkins
 
 exec gosu  jenkins /usr/bin/tini -- /usr/local/bin/jenkins.sh "$@"

--- a/terraform/Efimero/backend.tf
+++ b/terraform/Efimero/backend.tf
@@ -62,17 +62,17 @@ resource "aws_instance" "bere_backend" {
 
               sudo dnf clean all
               sudo dnf makecache
-
+              
+              sudo dnf install -y git
               sudo dnf install -y docker
+              sudo dnf install java-21-amazon-corretto-devel -y
+              sudo dnf install -y maven
               sudo systemctl start docker
               sudo systemctl enable docker
 
               sudo docker pull govench/bere-api:latest
-              sudo docker run -d -p 8080:8080 --restart always govench/bere-api:latest
-
-              sudo dnf install postgresql17 -y
-
-              echo "Script completado"
+              sudo docker run -d --name bere-api -p 8080:8080 --restart always govench/bere-api:latest
+              
               EOF
 
   tags = {

--- a/terraform/Efimero/rds.tf
+++ b/terraform/Efimero/rds.tf
@@ -50,11 +50,11 @@ resource "aws_db_instance" "bere_db" {
   vpc_security_group_ids  = [aws_security_group.rds_sg.id]
   db_subnet_group_name    = aws_db_subnet_group.bere_db_subnet.name
 
-  backup_retention_period = 0 # Desactiva backups para no salir del Free Tier
-  skip_final_snapshot     = true # Evita snapshot obligatorio al destruir
-  deletion_protection     = false # Puedes cambiar a true en producción
+  backup_retention_period = 0
+  skip_final_snapshot     = true 
+  deletion_protection     = false 
 
-  publicly_accessible     = false  #Activar para permitir local host
+  publicly_accessible     = false  
   multi_az                = false
 
   tags = {


### PR DESCRIPTION
**Modifique:**
**jenkins/docker-compose.yaml**, para tener acceso a la clave priavda ssh, no se uso directamente un copy dentro del dockerfile porque esto  expondria nuestras claves. La clave no se guarda dentro del contenedor ni en el sistema de archivos. Simplemente se monta en tiempo de ejecución. Cuando el contenedor se apaga o elimina, la clave no queda dentro.

**jenkins/entrypoint.sh**, para dar acceso sin necesidad de agregar fingerprint manualmente, evitara que SSH pregunte si confías en el host remoto la primera vez que te conectas.

The authenticity of host 'x.x.x.x' can't be established.
Are you sure you want to continue connecting (yes/no/[fingerprint])?

Esto podria romper los jobs que realizara jenkins, es por eso que se tuvo que agregar eso.

**terraform/Efimero/backend.tf**, Se agrego la instalación de , maven, git, jdk, y se especifico el nombre del contenedor en el cual se correrá el backend